### PR TITLE
fix: 修改 clangd 的配置命令

### DIFF
--- a/src/template_strs.ts
+++ b/src/template_strs.ts
@@ -31,7 +31,9 @@ export const generateSettingsJson = (avzDir: string, envType: number) => `{
     // 未安装 clangd vsc 扩展此配置无效
     "clangd.fallbackFlags": [
         "-I${avzDir}/inc",
-        "-std=${envType === 1 ? "c++14" : "c++2b"}"
+        "-m32",
+        "-std=${envType === 1 ? "c++14" : "c++20"}",
+        "${envType === 1 ? "" : "-fexperimental-library"}"
     ],
 
     // lldb-dap avz lldb executable-path 配置


### PR DESCRIPTION
- 修复低版本 clangd 无法识别 c++2b 的问题.
- 考虑到 AvZ2 的 CMake 脚本中使用 `-std=c++20` 作为编译参数, 将 clangd 的配置命令改为 `-std=c++20 -fexperimental-library` 应该问题不大 (?
- clangd 默认目标平台为 64 位, 应为配置命令添加 `-m32`, 避免在指针转 32 位整型等情况时发出警告.